### PR TITLE
Add a bookmarklet to see Govspeak of a Smart Answer

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,5 +47,9 @@
     <li>
       <a href="javascript:(function()%7Bvar%20req%20%3D%20new%20XMLHttpRequest()%3Breq.open('GET'%2C%20document.location%2C%20false)%3Breq.send(null)%3Bdocument.location%3Dreq.getAllResponseHeaders().match('Link%3A%20%3C(.*)%3E%3B%20rel%3D%22up%22')%5B1%5D%7D)()">PDF to Web</a> - Use on a Whitehall PDF to go to the page of publication it was uploaded to.
     </li>
+
+    <li>
+      <a href='javascript:(function()%7Bwindow.location%20=%20window.location.href.replace(window.location.hostname,%20%22www.preview.alphagov.co.uk%22)%20+%20%22.txt%22%7D)()'>See Govspeak</a> - Goes to the preview of a Smart Answer and shows its Govspeak markup. It only works on outcome pages.
+    </li>
   </ol>
 </body>


### PR DESCRIPTION
A recent change in Smart Answers [1] has allowed us to expose Govspeak markup
of Smart Answers outcomes. The feature is enabled in preview environment, but
not production. This bookmarklet takes the current URL, points it to preview
and appends `.txt` to it.

[1] - https://github.com/alphagov/smart-answers/commit/953ec18b3aef34abc6a6fa690e516f80b403961a

Un-encoded JS:

``` JavaScript
javascript:(function(){window.location = window.location.href.replace(window.location.hostname, "www.preview.alphagov.co.uk") + ".txt"})()
```
